### PR TITLE
fix: remove circular deps

### DIFF
--- a/src/shared.ts
+++ b/src/shared.ts
@@ -69,27 +69,4 @@ export const useTimeout = <T>(
     }),
   ])
 
-export const decodeMessageData = (data: any) => {
-  if (typeof data == 'string') {
-    return data
-  } else if (data instanceof Uint8Array || data instanceof ArrayBuffer) {
-    return new TextDecoder().decode(data)
-  } else if (data.buffer instanceof ArrayBuffer) {
-    return new TextDecoder().decode(data.buffer)
-  } else if (Array.isArray(data)) {
-    const out: string[] = []
-    const decoder = new TextDecoder()
-    for (const chunk of data) {
-      if (typeof chunk == 'string') {
-        out.push(chunk)
-      } else if (chunk instanceof Uint8Array || chunk instanceof ArrayBuffer) {
-        out.push(decoder.decode(chunk))
-      } else if (chunk.buffer instanceof ArrayBuffer) {
-        out.push(decoder.decode(chunk.buffer))
-      }
-    }
-    return out.join('')
-  } else {
-    throw new Error('[maria2 error] Message data cannot be decoded')
-  }
-}
+export { decodeMessageData } from './shims/decode.ts'

--- a/src/shims/decode.ts
+++ b/src/shims/decode.ts
@@ -1,0 +1,24 @@
+export const decodeMessageData = (data: any) => {
+  if (typeof data == 'string') {
+    return data
+  } else if (data instanceof Uint8Array || data instanceof ArrayBuffer) {
+    return new TextDecoder().decode(data)
+  } else if (data.buffer instanceof ArrayBuffer) {
+    return new TextDecoder().decode(data.buffer)
+  } else if (Array.isArray(data)) {
+    const out: string[] = []
+    const decoder = new TextDecoder()
+    for (const chunk of data) {
+      if (typeof chunk == 'string') {
+        out.push(chunk)
+      } else if (chunk instanceof Uint8Array || chunk instanceof ArrayBuffer) {
+        out.push(decoder.decode(chunk))
+      } else if (chunk.buffer instanceof ArrayBuffer) {
+        out.push(decoder.decode(chunk.buffer))
+      }
+    }
+    return out.join('')
+  } else {
+    throw new Error('[maria2 error] Message data cannot be decoded')
+  }
+}

--- a/src/shims/node.ts
+++ b/src/shims/node.ts
@@ -1,4 +1,4 @@
-import { decodeMessageData } from '../shared.ts'
+import { decodeMessageData } from './decode.ts'
 
 export const randomUUID = await (async () => {
   const nodeCrypto = await import('node:crypto')


### PR DESCRIPTION
Before, `src/shared.ts` dynamic imports `src/shims/node.ts`, while `src/shims/node.ts` imports `src/shared.ts`. So there is circular deps here.

In the node v18, it may cause node process exits unexpectedly. So I lift up the shared decode function.